### PR TITLE
Add the `to_u32` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,12 @@ impl FourCharCode {
     pub fn display(&self) -> Display {
         Display(u32::from_be(normalize(self.0)))
     }
+
+    /// Returns the underlying `u32` this [FourCharCode] represents
+    #[inline]
+    pub const fn as_u32(&self) -> u32 {
+        self.0
+    }
 }
 
 impl Default for FourCharCode {


### PR DESCRIPTION
This PR adds in a quick method to return the underlying `u32`, as I need it for my current use case!

I noticed this _was_ present in the `v0` branch, so I did copy the implementation over from there (and add in a very quick documentation summary). I opted against making the inner member `pub`, even though that is also the case on `v0`, to keep some level of encapsulation